### PR TITLE
fix: floor instead of cast for 0 indexed bins

### DIFF
--- a/src/db/sql.ts
+++ b/src/db/sql.ts
@@ -37,10 +37,10 @@ export abstract class SQLDB<V extends string, D extends string>
   private binSQL(dimension: D, binConfig: BinConfig) {
     const field = this.getName(dimension);
     return {
-      select: `cast(
+      select: `floor(
         (${field} - ${this.castBins(binConfig.start)})
         / ${this.castBins(binConfig.step)}
-      as int)`,
+      )::int`,
       where: `${field} BETWEEN ${binConfig.start} AND ${binConfig.stop}`
     };
   }


### PR DESCRIPTION
when `(field - start) / step` = 0.5, `cast( as int)` rounds up to 1.

Bug: the result is no 0 bin index.

Fix: `floor` is the correct behavior